### PR TITLE
Add command-line options to cegaltools/main.py

### DIFF
--- a/cegaltools/main.py
+++ b/cegaltools/main.py
@@ -1,3 +1,7 @@
+import argparse
+import os
+import sys
+
 from cegaltools.wells import Well
 from cegaltools.plotting import CegalWellPlotter as cwp
 import pandas as pd
@@ -6,13 +10,46 @@ import pandas as pd
 
 
 def main():
+    parser = get_parser()
+    args = parser.parse_args(sys.argv[1:])
+    path = r''
+    filename = r''
+    file_path = r''
 
-    #cegaltools = Well(filename='15_9-F-14.LAS', path=r'C:\Users\hilde\Dev\Cegal Lab')
+    if args.path:
+        path = args.path
 
-    #cegaltools.report()
-    #cegaltools.plot_correlation()
+    if args.filename:
+        # filename = path + os.sep + args.filename
+        filename = args.filename
 
-    train = pd.read_csv(r'C:\Users\hilde\Dev\force 2020 hackathon\train.csv', sep=';')
+    if path:
+        file_path = path + os.sep + filename
+    else:
+        file_path = filename
+
+    if not os.path.isfile(file_path):
+        parser.print_help(sys.stderr)
+        parser.exit(1)
+
+    if filename.lower().endswith('.las'):
+        plot_las_well(filename=filename, path=path)
+    elif filename.lower().endswith('.csv') and os.path.isfile(filename):
+        plot_csv_well(file_path)
+    else:
+        parser.print_help(sys.stderr)
+        parser.exit(1)
+
+def plot_las_well(filename, path):
+    # cegaltools = Well(filename='15_9-F-14.LAS', path=r'C:\Users\hilde\Dev\Cegal Lab')
+    cegaltools = Well(filename=filename, path=path)
+
+    cegaltools.report()
+    cegaltools.plot_correlation()
+
+def plot_csv_well(filename):
+    # filename = r'C:\Users\hilde\Dev\force 2020 hackathon\train.csv'
+    train = pd.read_csv(filename, sep=';')
 
     test_csv_well = Well(filename=train.loc[train.WELL == '15/9-13'][train.columns[1:]],
                          dataframe_name='15/9-13',
@@ -39,6 +76,22 @@ def main():
                   logs=test_csv_well.df().columns[1:-2],
                   lithology_logs='FORCE_2020_LITHOFACIES_LITHOLOGY',
                   lithology_proba_logs='FORCE_2020_LITHOFACIES_CONFIDENCE')
+
+def get_parser():
+    parser = argparse.ArgumentParser('python cegaltools/main.py',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument(
+        '--filename',
+        help="Filename for either a Las file or a Csv file to plot",
+        required=False,
+    )
+    parser.add_argument(
+        '--path',
+        help="Directory path",
+        required=False,
+    )
+    return parser
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Description
This pull-request adds command-line arguments  --filename and --path to cegaltools/main.py to enable running cegaltools to plot different files of either .las type or .csv type.

This change also moves the separate .las and .csv functionality to separate functions : `plot_las_well() and plot_csv_well()`

### Examples

1. Running Cegaltools without options will display the help:
```
python cegaltools/main.py 
usage: python cegaltools/main.py [-h] [--filename FILENAME] [--path PATH]

optional arguments:
  -h, --help           show this help message and exit
  --filename FILENAME  Filename for either a Las file or a Csv file to plot
                       (default: None)
  --path PATH          Directory path (default: None)
```

2. Cegaltools can be run with just a file name with either a .las or a .csv extension and call the correct plotting functions for each file type. The file has to exist in the directory where the script is called from.
```
python cegaltools/main.py --filename sample_2.0.las
```

3. Cegaltools can also be passed a path:
```
python cegaltools/main.py --path 'C:\Users\hilde\Dev\force 2020 hackathon' --filename train.csv
```

This change is useful for learning Cegaltools on the command line, maybe others will find it helpful.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC
